### PR TITLE
Version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * Same features as `deprecated_command` with group-specific messaging
   * `warn_on_subcommands` parameter to control warning propagation to subcommands
   * Stores deprecation metadata on group object for programmatic access
+* Add configurable Vault path prefix for secrets storage
+  * New environment variable `MODULAR_CLI_SDK_VAULT_PATH_PREFIX` to specify custom path prefix
+  * Secrets can now be stored under custom paths (e.g., `modular/modular-api.stm.user.configuration`)
+  * Default behavior unchanged (root level) when not configured
+* Add configurable Vault mount point via `MODULAR_CLI_SDK_VAULT_MOUNT_POINT` environment variable
+* Add `exists()` method to `SSMCredentialsManager` to check if configuration already exists
+* Add helper functions `get_vault_token()` and `get_vault_addr()` in constants module
+* Rename environment variables with backward compatibility:
+  * `MODULAR_CLI_VAULT_TOKEN` → `MODULAR_CLI_SDK_VAULT_TOKEN`
+  * `MODULAR_CLI_VAULT_ADDR` → `MODULAR_CLI_SDK_VAULT_ADDR`
+  * Old names are deprecated but still supported
 
 # [3.1.0] - 2025-11-05
 * Add library `click>=8.0.0,<9.0.0` to `pyproject.toml` dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [3.1.1] - 2026-01-14
+* Change name for decorator from `deprecated` to `deprecated_command`
+* Add `deprecated_group` decorator to mark CLI command groups as deprecated
+  * Same features as `deprecated_command` with group-specific messaging
+  * `warn_on_subcommands` parameter to control warning propagation to subcommands
+  * Stores deprecation metadata on group object for programmatic access
+
 # [3.1.0] - 2025-11-05
 * Add library `click>=8.0.0,<9.0.0` to `pyproject.toml` dependencies
 * Add `deprecated` decorator to mark commands as deprecated

--- a/modular_cli_sdk/client/ssm_client.py
+++ b/modular_cli_sdk/client/ssm_client.py
@@ -10,7 +10,16 @@ from botocore.client import ClientError
 from botocore.credentials import JSONFileCache
 from botocore.exceptions import NoCredentialsError, NoRegionError
 
-from modular_cli_sdk.commons.constants import ENV_VAULT_ADDR, ENV_VAULT_TOKEN
+from modular_cli_sdk.commons.constants import (
+    ENV_VAULT_ADDR,
+    ENV_VAULT_TOKEN,
+    ENV_VAULT_PATH_PREFIX,
+    ENV_VAULT_MOUNT_POINT,
+    DEFAULT_VAULT_MOUNT_POINT,
+    DEFAULT_VAULT_PATH_PREFIX,
+    get_vault_token,
+    get_vault_addr,
+)
 from modular_cli_sdk.commons.logger import get_logger
 
 _LOG = get_logger(__name__)
@@ -53,7 +62,9 @@ class OnPremSecretsManager(AbstractSecretsManager):
     emulate some parameter store. In case we really need on-prem,
     we must use Vault
     """
-    path = os.path.expanduser(os.path.join('~', '.modular_cli', 'on-prem', 'ssm'))
+    path = os.path.expanduser(
+        os.path.join('~', '.modular_cli', 'on-prem', 'ssm')
+    )
 
     def __init__(self):
         self._store = JSONFileCache(self.path)
@@ -75,23 +86,121 @@ class OnPremSecretsManager(AbstractSecretsManager):
 
 
 class VaultSecretsManager(AbstractSecretsManager):
-    mount_point = 'kv'
-    key = 'data'
+    """
+    Vault KV v2 secrets manager.
 
-    def __init__(self):
-        self._client = None  # hvac.Client
+    Supports configurable mount point and path prefix via:
+    - Constructor parameters (highest priority)
+    - Environment variables - new names (recommended)
+    - Environment variables - old names (deprecated, backward compatible)
+    - Default values (lowest priority)
+
+    Environment variable precedence:
+    - MODULAR_CLI_SDK_VAULT_* (new, recommended)
+    - MODULAR_CLI_VAULT_* (old, deprecated but supported)
+    """
+
+    KEY = 'kv'
+
+    def __init__(
+            self,
+            mount_point: Optional[str] = None,
+            path_prefix: Optional[str] = None,
+            url: Optional[str] = None,
+            token: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize VaultSecretsManager.
+
+        :param mount_point: Vault KV mount point (default: 'secret' or from env)
+        :param path_prefix: Path prefix for secrets (default: '' or from env)
+        :param url: Vault server URL (default: from env)
+        :param token: Vault token (default: from env)
+        """
+        self._client = None
+        self._mount_point = mount_point
+        self._path_prefix = path_prefix
+        self._url = url
+        self._token = token
+
+    @property
+    def mount_point(self) -> str:
+        """Get mount point from constructor, env var, or default."""
+        if self._mount_point is not None:
+            return self._mount_point
+        return os.getenv(ENV_VAULT_MOUNT_POINT, DEFAULT_VAULT_MOUNT_POINT)
+
+    @property
+    def path_prefix(self) -> str:
+        """Get path prefix from constructor, env var, or default."""
+        if self._path_prefix is not None:
+            return self._path_prefix
+        return os.getenv(ENV_VAULT_PATH_PREFIX, DEFAULT_VAULT_PATH_PREFIX)
+
+    @property
+    def url(self) -> Optional[str]:
+        """
+        Get Vault URL with backward compatibility.
+        Priority: constructor > new env var > old env var
+        """
+        if self._url:
+            return self._url
+        return get_vault_addr()
+
+    @property
+    def token(self) -> Optional[str]:
+        """
+        Get Vault token with backward compatibility.
+        Priority: constructor > new env var > old env var
+        """
+        if self._token:
+            return self._token
+        return get_vault_token()
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """Normalize path by removing leading/trailing slashes."""
+        return path.strip('/') if path else ''
+
+    def _build_full_path(self, name: str) -> str:
+        """
+        Build full path with optional prefix.
+
+        Examples:
+            - name='secret.name', prefix='' -> 'secret.name'
+            - name='secret.name', prefix='modular' -> 'modular/secret.name'
+        """
+        prefix = self._normalize_path(self.path_prefix)
+        name = self._normalize_path(name)
+
+        if prefix:
+            return f'{prefix}/{name}'
+        return name
 
     def _init_client(self):
         try:
             import hvac
         except ImportError:
-            raise RuntimeError('Install hvac to use Vault client. '
-                               '"pip install hvac==0.11.2"')
-        _LOG.debug('Initializing hvac client')
-        self._client = hvac.Client(
-            url=os.getenv(ENV_VAULT_ADDR),
-            token=os.getenv(ENV_VAULT_TOKEN)
-        )
+            raise RuntimeError(
+                'Install hvac to use Vault client. "pip install hvac==0.11.2"'
+            )
+
+        url = self.url
+        token = self.token
+
+        if not url:
+            raise RuntimeError(
+                f'Vault URL not configured. Set {ENV_VAULT_ADDR} environment '
+                f'variable or pass url parameter.'
+            )
+        if not token:
+            raise RuntimeError(
+                f'Vault token not configured. Set {ENV_VAULT_TOKEN} environment'
+                f' variable or pass token parameter.'
+            )
+
+        _LOG.debug(f'Initializing hvac client for URL: {url}')
+        self._client = hvac.Client(url=url, token=token)
         _LOG.debug('Hvac client was initialized')
 
     @property
@@ -101,38 +210,67 @@ class VaultSecretsManager(AbstractSecretsManager):
         return self._client
 
     def get_parameter(self, name: str) -> Optional[SecretValue]:
+        full_path = self._build_full_path(name)
+        _LOG.debug(f'Getting parameter from path: {full_path}')
         try:
             response = self.client.secrets.kv.v2.read_secret_version(
-                path=name, mount_point=self.mount_point) or {}
-        except Exception:  # hvac.InvalidPath
-            return
-        return response.get('data', {}).get('data', {}).get(self.key)
+                path=full_path,
+                mount_point=self.mount_point,
+            ) or {}
+        except Exception as e:
+            _LOG.debug(f'Failed to get parameter {full_path}: {e}')
+            return None
+        return response.get('data', {}).get('data', {}).get(self.KEY)
 
-    def put_parameter(self, name: str, value: SecretValue,
-                      _type='SecureString') -> bool:
-        self.client.secrets.kv.v2.create_or_update_secret(
-            path=name,
-            secret={self.key: value},
-            mount_point=self.mount_point
-        )
-        return True
+    def put_parameter(
+            self,
+            name: str,
+            value: SecretValue,
+            _type='SecureString',
+    ) -> bool:
+        full_path = self._build_full_path(name)
+        _LOG.debug(f'Putting parameter to path: {full_path}')
+        try:
+            self.client.secrets.kv.v2.create_or_update_secret(
+                path=full_path,
+                secret={self.KEY: value},
+                mount_point=self.mount_point,
+            )
+            return True
+        except Exception as e:
+            _LOG.error(f'Failed to put parameter {full_path}: {e}')
+            return False
 
     def delete_parameter(self, name: str) -> bool:
-        return bool(self.client.secrets.kv.v2.delete_metadata_and_all_versions(
-            path=name, mount_point=self.mount_point))
+        full_path = self._build_full_path(name)
+        _LOG.debug(f'Deleting parameter from path: {full_path}')
+        try:
+            result = self.client.secrets.kv.v2.delete_metadata_and_all_versions(
+                path=full_path,
+                mount_point=self.mount_point,
+            )
+            return bool(result)
+        except Exception as e:
+            _LOG.error(f'Failed to delete parameter {full_path}: {e}')
+            return False
 
-    def enable_secrets_engine(self, mount_point=None) -> bool:
+    def enable_secrets_engine(self, mount_point: Optional[str] = None) -> bool:
+        target_mount = mount_point or self.mount_point
         try:
             self.client.sys.enable_secrets_engine(
                 backend_type='kv',
-                path=(mount_point or self.mount_point),
+                path=target_mount,
                 options={'version': 2}
             )
             return True
-        except Exception:  # hvac.exceptions.InvalidRequest
-            return False  # already exists
+        except Exception as e:
+            _LOG.debug(f'Failed to enable secrets engine: {e}')
+            return False
 
-    def is_secrets_engine_enabled(self, mount_point=None) -> bool:
+    def is_secrets_engine_enabled(
+            self,
+            mount_point: Optional[str] = None,
+    ) -> bool:
         mount_points = self.client.sys.list_mounted_secrets_engines()
         target_point = mount_point or self.mount_point
         return f'{target_point}/' in mount_points
@@ -150,44 +288,54 @@ class SSMSecretsManager(AbstractSecretsManager):
         except NoCredentialsError:
             raise ValueError('No aws credentials could be found')
         except NoRegionError:
-            raise ValueError('No aws region could be found. Set AWS_DEFAULT_REGION environment')
+            raise ValueError(
+                'No aws region could be found. Set AWS_DEFAULT_REGION environment'
+            )
 
     def get_parameter(self, name: str) -> Optional[SecretValue]:
         try:
             response = self.client.get_parameter(
                 Name=name,
-                WithDecryption=True
+                WithDecryption=True,
             )
             value_str = response['Parameter']['Value']
-            _LOG.debug(f'Configuration \'{name}\' from SSM received')
+            _LOG.debug(f"Configuration '{name}' from SSM received")
             try:
                 return json.loads(value_str)
             except json.JSONDecodeError:
-                _LOG.warning('Could not load json from SSM value. '
-                             'Returning raw string')
+                _LOG.warning(
+                    'Could not load json from SSM value. Returning raw string'
+                )
                 return value_str
         except ClientError as e:
             error_code = e.response['Error']['Code']
-            _LOG.error(f'Can\'t get secret for name \'{name}\', '
-                       f'error code: \'{error_code}\'')
-            return
+            _LOG.error(
+                f"Can't get secret for name '{name}', error code: '{error_code}'"
+            )
+            return None
 
-    def put_parameter(self, name: str, value: SecretValue,
-                      _type='SecureString') -> bool:
+    def put_parameter(
+            self,
+            name: str,
+            value: SecretValue,
+            _type='SecureString',
+    ) -> bool:
         try:
             if isinstance(value, (list, dict)):
                 value = json.dumps(value)
-            _LOG.debug(f'Saving \'{name}\' to SSM')
+            _LOG.debug(f"Saving '{name}' to SSM")
             self.client.put_parameter(
                 Name=name,
                 Value=value,
                 Overwrite=True,
-                Type=_type)
+                Type=_type,
+            )
             return True
         except ClientError as e:
             error_code = e.response['Error']['Code']
-            _LOG.error(f'Can\'t put secret for name \'{name}\', '
-                       f'error code: \'{error_code}\'')
+            _LOG.error(
+                f"Can't put secret for name '{name}', error code: '{error_code}'"
+            )
             return False
 
     def delete_parameter(self, name: str) -> bool:
@@ -196,7 +344,8 @@ class SSMSecretsManager(AbstractSecretsManager):
             self.client.delete_parameter(Name=name)
         except ClientError as e:
             error_code = e.response['Error']['Code']
-            _LOG.error(f'Can\'t delete secret name \'{name}\', '
-                       f'error code: \'{error_code}\'')
+            _LOG.error(
+                f"Can't delete secret name '{name}', error code: '{error_code}'"
+            )
             return False
         return True

--- a/modular_cli_sdk/commons/constants.py
+++ b/modular_cli_sdk/commons/constants.py
@@ -1,4 +1,46 @@
-ENV_VAULT_TOKEN = 'MODULAR_CLI_VAULT_TOKEN'
-ENV_VAULT_ADDR = 'MODULAR_CLI_VAULT_ADDR'  # full one like https://127.0.0.1:8200/
+import os
+from typing import Optional
 
+# =============================================================================
+# NEW Environment variable names (recommended)
+# =============================================================================
+ENV_VAULT_TOKEN = 'MODULAR_CLI_SDK_VAULT_TOKEN'
+ENV_VAULT_ADDR = 'MODULAR_CLI_SDK_VAULT_ADDR'
+ENV_VAULT_PATH_PREFIX = 'MODULAR_CLI_SDK_VAULT_PATH_PREFIX'
+ENV_VAULT_MOUNT_POINT = 'MODULAR_CLI_SDK_VAULT_MOUNT_POINT'
+
+# =============================================================================
+# OLD Environment variable names (deprecated, kept for backward compatibility)
+# =============================================================================
+ENV_VAULT_TOKEN_OLD = 'MODULAR_CLI_VAULT_TOKEN'
+ENV_VAULT_ADDR_OLD = 'MODULAR_CLI_VAULT_ADDR'
+
+# =============================================================================
+# Default values
+# =============================================================================
+DEFAULT_VAULT_MOUNT_POINT = 'secret'
+DEFAULT_VAULT_PATH_PREFIX = ''  # Empty = root level (old behavior)
+
+# =============================================================================
+# Context keys
+# =============================================================================
 CONTEXT_MODULAR_ADMIN_USERNAME = 'modular_admin_username'
+
+
+# =============================================================================
+# Helper functions (evaluated at runtime, with backward compatibility)
+# =============================================================================
+def get_vault_token() -> Optional[str]:
+    """
+    Get Vault token with backward compatibility.
+    Priority: new env var > old env var
+    """
+    return os.environ.get(ENV_VAULT_TOKEN) or os.environ.get(ENV_VAULT_TOKEN_OLD)
+
+
+def get_vault_addr() -> Optional[str]:
+    """
+    Get Vault address with backward compatibility.
+    Priority: new env var > old env var
+    """
+    return os.environ.get(ENV_VAULT_ADDR) or os.environ.get(ENV_VAULT_ADDR_OLD)

--- a/modular_cli_sdk/services/credentials_manager.py
+++ b/modular_cli_sdk/services/credentials_manager.py
@@ -4,13 +4,21 @@ import shutil
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
+from typing import Optional
 
-from modular_cli_sdk.client.ssm_client import SSMSecretsManager, \
-    AbstractSecretsManager, VaultSecretsManager
-from modular_cli_sdk.commons.constants import CONTEXT_MODULAR_ADMIN_USERNAME, \
-    ENV_VAULT_TOKEN, ENV_VAULT_ADDR
-from modular_cli_sdk.commons.exception import \
-    ModularCliSdkConfigurationException
+from modular_cli_sdk.client.ssm_client import (
+    SSMSecretsManager,
+    AbstractSecretsManager,
+    VaultSecretsManager,
+)
+from modular_cli_sdk.commons.constants import (
+    CONTEXT_MODULAR_ADMIN_USERNAME,
+    get_vault_token,
+    get_vault_addr,
+)
+from modular_cli_sdk.commons.exception import (
+    ModularCliSdkConfigurationException,
+)
 from modular_cli_sdk.commons.logger import get_logger
 
 _LOG = get_logger(__name__)
@@ -41,12 +49,36 @@ class AbstractCredentialsManager(ABC):
         installation or remove parameter from AWS Parameter Store if module is a
         part of Modular-API
         """
+        ...
+
+    @abstractmethod
+    def exists(self) -> bool:
+        """
+        Check if configuration already exists
+        """
+        ...
 
 
 class CredentialsProvider:
-    def __init__(self, module_name, context):
+    def __init__(
+            self,
+            module_name: str,
+            context,
+            vault_path_prefix: Optional[str] = None,
+            vault_mount_point: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize CredentialsProvider.
+
+        :param module_name: Name of the module/tool
+        :param context: Click context
+        :param vault_path_prefix: Optional path prefix for Vault storage
+        :param vault_mount_point: Optional mount point for Vault storage
+        """
         self.module_name = module_name
         self.context = context
+        self.vault_path_prefix = vault_path_prefix
+        self.vault_mount_point = vault_mount_point
 
     def is_modular_mode(self) -> bool:
         """
@@ -59,9 +91,14 @@ class CredentialsProvider:
         return bool(obj.get(CONTEXT_MODULAR_ADMIN_USERNAME))
 
     @property
-    def credentials_manager(self):
+    def credentials_manager(self) -> AbstractCredentialsManager:
         if self.is_modular_mode():
-            instance = SSMCredentialsManager(self.module_name, self.context)
+            instance = SSMCredentialsManager(
+                module_name=self.module_name,
+                context=self.context,
+                vault_path_prefix=self.vault_path_prefix,
+                vault_mount_point=self.vault_mount_point,
+            )
         else:
             instance = FileSystemCredentialsManager(self.module_name)
         return instance
@@ -73,8 +110,8 @@ class FileSystemCredentialsManager(AbstractCredentialsManager):
         home = str(Path.home())
         self.module_name = module_name
         self.creds_folder_path = os.path.join(home, f'.{module_name}')
-        self.config_file_path = os.path.join(self.creds_folder_path,
-                                             'credentials')
+        self.config_file_path = \
+            os.path.join(self.creds_folder_path, 'credentials')
 
     def store(self, config: dict) -> str:
         try:
@@ -82,7 +119,8 @@ class FileSystemCredentialsManager(AbstractCredentialsManager):
         except OSError as e:
             _LOG.error(
                 f'Unable to create configuration folder '
-                f'{self.creds_folder_path}. Reason: {str(e)}')
+                f'{self.creds_folder_path}. Reason: {str(e)}'
+            )
             raise ModularCliSdkConfigurationException(
                 f'Unable to create configuration folder {self.creds_folder_path}'
             )
@@ -91,7 +129,8 @@ class FileSystemCredentialsManager(AbstractCredentialsManager):
             json.dump(config, config_file)
         _LOG.debug(
             f'Configuration created successfully. Stored by path: '
-            f'{self.config_file_path}')
+            f'{self.config_file_path}'
+        )
         # todo review:fix
         # TODO, I think it's bad to return these obviously human strings here.
         #  We should return bool or None or smt, and the user of this class
@@ -102,17 +141,21 @@ class FileSystemCredentialsManager(AbstractCredentialsManager):
         #  strings in case the config was or wasn't cleaned. And how is the
         #  programmers supposed to know, whether the config was cleaned?
         #  By using regex?
-        return f'The configuration for {self.module_name} tool was ' \
-               f'successfully saved locally'
+        return (
+            f'The configuration for {self.module_name} tool was successfully '
+            f'saved locally'
+        )
 
     def extract(self) -> dict:
         if not os.path.exists(self.config_file_path):
             _LOG.error(
                 f'Can not find configuration file by path: '
-                f'{self.config_file_path}')
+                f'{self.config_file_path}'
+            )
             raise ModularCliSdkConfigurationException(
                 f'The {self.module_name} tool is not configured. '
-                f'Please execute the configuration command')
+                f'Please execute the configuration command'
+            )
         with open(self.config_file_path, 'r') as config_file:
             config_dict = json.load(config_file)
         _LOG.debug('Configuration successfully loaded')
@@ -122,29 +165,43 @@ class FileSystemCredentialsManager(AbstractCredentialsManager):
         try:
             shutil.rmtree(self.creds_folder_path)
         except FileNotFoundError:
-            return f'Configuration for {self.module_name} tool not found. ' \
-                   f'Nothing to delete'
+            return (
+                f'Configuration for {self.module_name} tool not found. '
+                f'Nothing to delete'
+            )
         except OSError:
             _LOG.error(
                 f'Error occurred while cleaning {self.module_name} '
-                f'configuration by path: {self.creds_folder_path}.')
+                f'configuration by path: {self.creds_folder_path}.'
+            )
         return f'The {self.module_name} tool configuration has been deleted.'
 
 
 class SSMCredentialsManager(AbstractCredentialsManager):
 
-    def __init__(self, module_name: str, context):
+    def __init__(
+            self,
+            module_name: str,
+            context,
+            vault_path_prefix: Optional[str] = None,
+            vault_mount_point: Optional[str] = None,
+    ) -> None:
         """
         :param module_name: str
         :param context: click.Context
+        :param vault_path_prefix: Optional path prefix for Vault storage
+        :param vault_mount_point: Optional mount point for Vault storage
         """
         self.context = context
+        self._vault_path_prefix = vault_path_prefix
+        self._vault_mount_point = vault_mount_point
+
         user_name = context.obj[CONTEXT_MODULAR_ADMIN_USERNAME]
         user_name = AbstractSecretsManager.allowed_name(user_name)
         self.module_name = module_name
         self.ssm_secret_name = self.build_ssm_secret_name(
             module_name=module_name,
-            user_name=user_name
+            user_name=user_name,
         )
 
     @staticmethod
@@ -154,24 +211,34 @@ class SSMCredentialsManager(AbstractCredentialsManager):
     @cached_property
     def ssm_client(self) -> AbstractSecretsManager:
         """
-        Can possibly return any implemented client
-        :return:
+        Returns the appropriate secrets manager based on configuration.
+
+        Priority:
+        1. Vault (if VAULT_TOKEN and VAULT_ADDR are set - new or old env vars)
+        2. AWS SSM (fallback)
+
+        :return: AbstractSecretsManager instance
         """
-        if os.environ.get(ENV_VAULT_TOKEN) and os.environ.get(ENV_VAULT_ADDR):
-            _LOG.debug('Returning vault secrets manager')
-            return VaultSecretsManager()
+        if get_vault_token() and get_vault_addr():
+            _LOG.debug('Returning Vault secrets manager')
+            return VaultSecretsManager(
+                path_prefix=self._vault_path_prefix,
+                mount_point=self._vault_mount_point,
+            )
         _LOG.debug('Returning SSM secrets manager')
         return SSMSecretsManager()
 
     def store(self, config: dict) -> str:
         saved = self.ssm_client.put_parameter(
             name=self.ssm_secret_name,
-            value=config
+            value=config,
         )
         if saved:
-            return f'The configuration for {self.module_name} tool was ' \
-                   f'successfully saved remotely. Parameter name: ' \
-                   f'{self.ssm_secret_name}'
+            return (
+                f'The configuration for {self.module_name} tool was '
+                f'successfully saved remotely. Parameter name: '
+                f'{self.ssm_secret_name}'
+            )
         raise ModularCliSdkConfigurationException(
             f'Unable to save configuration for {self.module_name} to SSM'
         )
@@ -181,18 +248,33 @@ class SSMCredentialsManager(AbstractCredentialsManager):
         if not result:
             raise ModularCliSdkConfigurationException(
                 f'The {self.module_name} tool is not configured. '
-                f'Please execute the configuration command')
+                f'Please execute the configuration command'
+            )
         if isinstance(result, str):
             raise ModularCliSdkConfigurationException(
                 'Can not load configuration. For more information '
-                'please check logs')
-        # isinstance(result, (dict, list))
+                'please check logs'
+            )
         return result
 
     def clean_up(self) -> str:
         removed = self.ssm_client.delete_parameter(name=self.ssm_secret_name)
         if not removed:
-            return f'Configuration for {self.module_name} tool not found. ' \
-                   f'Nothing to delete'
-        return f'Configuration for {self.module_name} tool was successfully ' \
-               f'deleted'
+            return (
+                f'Configuration for {self.module_name} tool not found. '
+                f'Nothing to delete'
+            )
+        return (
+            f'Configuration for {self.module_name} tool was successfully deleted'
+        )
+
+    def exists(self) -> bool:
+        """Check if configuration already exists."""
+        try:
+            result = self.ssm_client.get_parameter(name=self.ssm_secret_name)
+            return result is not None
+        except Exception as e:
+            _LOG.debug(
+                f'Failed to check if secret exists {self.ssm_secret_name}: {e}'
+            )
+            return False

--- a/modular_cli_sdk/utils/view_utils.py
+++ b/modular_cli_sdk/utils/view_utils.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import datetime as _dt
 import functools
-from typing import Any, Callable, Optional, Union, Dict
+from typing import Any, Callable, Optional, Union, Dict, TypeVar
 
 import click
+
+G = TypeVar('G', bound=click.MultiCommand)
 
 
 def _parse_date(
@@ -32,54 +34,52 @@ def _days_until(
 
 def _format_block(
         info: Dict[str, Any],
+        entity_type: str = "command",
 ) -> list[str]:
     """Build deprecation block lines."""
     days_left = _days_until(info["removal_date"])
     removal_str = info["removal_date"].isoformat()
-    IND = "  "
     SEP = "=" * 69
 
     lines = [
-        f"{IND}{SEP}",
-        f"{IND}WARNING: This command is DEPRECATED"
+        SEP,
+        f"WARNING: This {entity_type} is DEPRECATED"
     ]
 
     if info.get("deprecated_date"):
         lines.append(
-            f"{IND}Deprecated since: {info['deprecated_date'].isoformat()}"
+            f"Deprecated since: {info['deprecated_date'].isoformat()}"
         )
 
     if info.get("version"):
-        lines.append(f"{IND}Deprecated in version: {info['version']}")
+        lines.append(f"Deprecated in version: {info['version']}")
 
     if days_left > 30:
         lines.append(
-            f"{IND}Scheduled for removal on: {removal_str} ({days_left} "
-            f"days left)"
+            f"Scheduled for removal on: {removal_str} ({days_left} days left)"
         )
     elif days_left > 0:
         lines.append(
-            f"{IND}Will be REMOVED in {days_left} days on: {removal_str}"
+            f"Will be REMOVED in {days_left} days on: {removal_str}"
         )
     elif days_left == 0:
-        lines.append(f"{IND}Will be REMOVED TODAY on: {removal_str}")
+        lines.append(f"Will be REMOVED TODAY on: {removal_str}")
     else:
         lines.append(
-            f"{IND}REMOVAL DATE PASSED on: {removal_str} ({abs(days_left)} "
-            f"days ago)"
+            f"REMOVAL DATE PASSED on: {removal_str} ({abs(days_left)} days ago)"
         )
 
     if info.get("alternative"):
-        lines.append(f"{IND}Use instead: {info['alternative']}")
+        lines.append(f"Use instead: {info['alternative']}")
 
     if info.get("reason"):
-        lines.append(f"{IND}Reason: {info['reason']}")
+        lines.append(f"Reason: {info['reason']}")
 
-    lines.append(f"{IND}{SEP}")
+    lines.append(SEP)
     return lines
 
 
-def deprecated(
+def deprecated_command(
         *,
         removal_date: Union[str, _dt.date],
         alternative: Optional[str] = None,
@@ -94,6 +94,7 @@ def deprecated(
     Decorator for marking Click commands/functions as deprecated.
 
     Shows a runtime warning and injects a block into --help.
+    For Click groups, use @deprecated_group instead.
 
     Args:
         removal_date: Date when command will be removed (YYYY-MM-DD)
@@ -102,6 +103,17 @@ def deprecated(
         version: Version where deprecation was introduced
         reason: Explanation for deprecation
         enforce_removal: If True, raises error after removal_date passes
+
+    Example:
+        @deprecated_command(
+            removal_date='2027-01-01',
+            deprecated_date='2025-06-01',
+            reason='Feature removed',
+            alternative='m3admin new-cmd'
+        )
+        @cli.command()
+        def old_cmd():
+            pass
     """
     removal_d = _parse_date(removal_date)
     if not removal_d:
@@ -123,7 +135,7 @@ def deprecated(
 
         # Check if removal date has passed and enforcement is enabled
         if enforce_removal and days_left < 0:
-            click.secho("  " + "=" * 69, fg="red", bold=True, err=True)
+            click.secho("=" * 69, fg="red", bold=True, err=True)
             click.secho(
                 message="  ERROR: This command has been REMOVED!",
                 fg="red",
@@ -146,7 +158,7 @@ def deprecated(
                     bold=True,
                     err=True,
                 )
-            click.secho("  " + "=" * 69, fg="red", bold=True, err=True)
+            click.secho("=" * 69, fg="red", bold=True, err=True)
             raise click.UsageError(
                 f"Command removed on {removal_d.isoformat()}. Use: "
                 f"{alternative if alternative else 'See documentation for alternatives'}"
@@ -181,7 +193,6 @@ def deprecated(
     def _decorate_command(
             cmd: click.Command,
     ) -> click.Command:
-        original_help = cmd.help
         orig_cb = cmd.callback or (lambda *a, **kw: None)
 
         @functools.wraps(orig_cb)
@@ -196,42 +207,21 @@ def deprecated(
                 formatter: click.HelpFormatter,
         ) -> None:
             """Custom help formatter that injects deprecation warning."""
+            cmd.format_usage(ctx, formatter)
 
-            # 1. Write Usage section
-            pieces = cmd.collect_usage_pieces(ctx)
-            formatter.write_usage(
-                prog=ctx.command_path,
-                args=' '.join(pieces) if pieces else '',
-            )
-            formatter.write_paragraph()
-
-            # 2. Write deprecation block WITH COLORS
+            # Write deprecation block with colors
             days_left = _days_until(base_info["removal_date"])
             color = "yellow" if days_left > 30 else "red"
 
+            formatter.write_paragraph()
             for line in _format_block(base_info):
-                # Apply color styling
                 styled_line = click.style(line, fg=color, bold=True)
                 formatter.write(styled_line)
                 formatter.write('\n')
-            formatter.write_paragraph()
 
-            # 3. Write command description/help
-            help_text = original_help or ''
-            if isinstance(help_text, str) and help_text:
-                formatter.indent()
-                formatter.write_text(help_text)
-                formatter.dedent()
-
-            # 4. Write Options section
+            cmd.format_help_text(ctx, formatter)
             cmd.format_options(ctx, formatter)
-
-            # 5. Write epilog if present
-            if cmd.epilog:
-                formatter.write_paragraph()
-                epilog_text = cmd.epilog if isinstance(cmd.epilog, str) \
-                    else str(cmd.epilog)
-                formatter.write_text(epilog_text)
+            cmd.format_epilog(ctx, formatter)
 
         cmd.format_help = format_help
         return cmd
@@ -239,12 +229,175 @@ def deprecated(
     def _decorator(
             target: Union[Callable[..., Any], click.Command],
     ) -> Union[Callable[..., Any], click.Command]:
+        if isinstance(target, click.MultiCommand):
+            raise TypeError(
+                "@deprecated_command cannot be used on click.Group/MultiCommand. "
+                "Use @deprecated_group instead."
+            )
         if isinstance(target, click.Command):
             return _decorate_command(target)
         if callable(target):
             return _decorate_function(target)
         raise TypeError(
-            "@deprecated can only decorate a function or click.Command."
+            "@deprecated_command can only decorate a function or click.Command."
         )
 
     return _decorator
+
+
+def deprecated_group(
+        *,
+        removal_date: Union[str, _dt.date],
+        alternative: Optional[str] = None,
+        deprecated_date: Optional[Union[str, _dt.date]] = None,
+        version: Optional[str] = None,
+        reason: Optional[str] = None,
+        enforce_removal: bool = False,
+        warn_on_subcommands: bool = True,
+) -> Callable[[G], G]:
+    """
+    Decorator for marking Click groups/multi-commands as deprecated.
+
+    Shows a runtime warning and injects a block into --help.
+
+    Args:
+        removal_date: Date when group will be removed (YYYY-MM-DD)
+        alternative: Suggested replacement
+        deprecated_date: Date when deprecation started (YYYY-MM-DD)
+        version: Version where deprecation was introduced
+        reason: Explanation for deprecation
+        enforce_removal: If True, raises error after removal_date passes
+        warn_on_subcommands: If True (default), shows warning when any
+                            subcommand is executed (not when viewing
+                            subcommand help)
+
+    Example:
+        @deprecated_group(
+            removal_date='2027-01-01',
+            deprecated_date='2025-06-01',
+            reason='Integration being removed',
+        )
+        @cli.group()
+        def old_group():
+            pass
+    """
+    removal_d = _parse_date(removal_date)
+    if not removal_d:
+        raise ValueError("removal_date is required and must be YYYY-MM-DD")
+    deprecated_d = _parse_date(deprecated_date)
+    if alternative is not None and not isinstance(alternative, str):
+        raise ValueError("alternative must be a string if provided")
+
+    base_info = dict(
+        removal_date=removal_d,
+        alternative=alternative,
+        deprecated_date=deprecated_d,
+        version=version,
+        reason=reason,
+    )
+
+    def _emit_warning():
+        days_left = _days_until(removal_d)
+
+        if enforce_removal and days_left < 0:
+            click.secho("=" * 69, fg="red", bold=True, err=True)
+            click.secho(
+                message="  ERROR: This command group has been REMOVED!",
+                fg="red",
+                bold=True,
+                err=True,
+            )
+            click.secho(
+                message=(
+                    f"  Removal date: {removal_d.isoformat()} ({abs(days_left)}"
+                    f" days ago)"
+                ),
+                fg="red",
+                bold=True,
+                err=True,
+            )
+            if alternative:
+                click.secho(
+                    message=f"  Use instead: {alternative}",
+                    fg="red",
+                    bold=True,
+                    err=True,
+                )
+            click.secho("=" * 69, fg="red", bold=True, err=True)
+            raise click.UsageError(
+                f"Command group removed on {removal_d.isoformat()}. Use: "
+                f"{alternative if alternative else 'See documentation for alternatives'}"
+            )
+
+        color = "yellow" if days_left > 30 else "red"
+        for line in _format_block(base_info, entity_type="command group"):
+            click.secho(message=line, fg=color, bold=True, err=True)
+
+    def decorator(grp: G) -> G:
+        if not isinstance(grp, click.MultiCommand):
+            raise TypeError(
+                f"@deprecated_group expects click.Group/MultiCommand, "
+                f"got {type(grp)!r}. "
+                f"Use @deprecated_command for commands/functions."
+            )
+
+        # Store deprecation info on the group object for meta generation
+        grp._deprecation_info = {
+            'removal_date': removal_d.isoformat(),
+            'deprecated_date': deprecated_d.isoformat() if deprecated_d else None,
+            'alternative': alternative,
+            'version': version,
+            'reason': reason,
+            'enforce_removal': enforce_removal,
+        }
+        # Remove None values
+        grp._deprecation_info = {
+            k: v for k, v in grp._deprecation_info.items() if v is not None
+        }
+
+        orig_invoke = grp.invoke
+
+        @functools.wraps(orig_invoke)
+        def wrapped_invoke(ctx: click.Context) -> Any:
+            subcommand = ctx.invoked_subcommand
+            has_subcommand = subcommand is not None or bool(ctx.protected_args)
+            help_requested = '--help' in ctx.args or '-h' in ctx.args
+
+            should_warn = False
+            if has_subcommand and help_requested:
+                should_warn = False
+            elif not has_subcommand:
+                should_warn = True
+            elif warn_on_subcommands:
+                should_warn = True
+
+            if should_warn:
+                _emit_warning()
+
+            return orig_invoke(ctx)
+
+        grp.invoke = wrapped_invoke
+
+        def format_help(
+                ctx: click.Context,
+                formatter: click.HelpFormatter,
+        ) -> None:
+            grp.format_usage(ctx, formatter)
+
+            days_left = _days_until(base_info["removal_date"])
+            color = "yellow" if days_left > 30 else "red"
+
+            formatter.write_paragraph()
+            for line in _format_block(base_info, entity_type="command group"):
+                styled_line = click.style(line, fg=color, bold=True)
+                formatter.write(styled_line)
+                formatter.write('\n')
+
+            grp.format_help_text(ctx, formatter)
+            grp.format_options(ctx, formatter)
+            grp.format_epilog(ctx, formatter)
+
+        grp.format_help = format_help
+        return grp
+
+    return decorator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "modular-cli-sdk"
-version = "3.1.0"
+version = "3.1.1"
 authors = [
     {name = "EPAM Systems", email = "support@syndicate.team"}
 ]


### PR DESCRIPTION
Change name for decorator from `deprecated` to `deprecated_command`
Add `deprecated_group` decorator to mark CLI command groups as deprecated
Add configurable Vault path prefix for secrets storage
Add configurable Vault mount point via `MODULAR_CLI_SDK_VAULT_MOUNT_POINT` environment variable
Add `exists()` method to `SSMCredentialsManager` to check if configuration already exists
Add helper functions `get_vault_token()` and `get_vault_addr()` in constants module
Rename environment variables with backward compatibility